### PR TITLE
Setup workflow grid generator command

### DIFF
--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -51,6 +51,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
    * Workflow configuration values.
    *
    * Each key corresponds to a config key in the template file.
+   *
    * @see /templates/tripal_admin/readme-grid-workflow.twig
    *
    * @var string
@@ -59,7 +60,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
     'name' => 'PHPUnit',
     'branches' => [
       '4.x',
-      'tv4g0-issue2247-support-php-8.4'
+      'tv4g0-issue2247-support-php-8.4',
     ],
     'cron' => '0 6 * * *',
     'test' => 'running-tests',
@@ -193,10 +194,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
           // Short hand instruction without PHP, will exclude all Drupal version
           // for every PHP version in the strategy.
           foreach ($strategy_matrix[self::WORKFLOW_VERSION['php']] as $php) {
-            foreach ($strategy_matrix[self::WORKFLOW_VERSION['pgsql']] as $pgsql) {
-              unset($webserver_stack[$php][$drupal][$pgsql]);
-            }
-
+            unset($webserver_stack[$php][$drupal]);
             $exclusion_note[] = '## PHP ' . $php . ' - Drupal ' . $drupal;
           }
 
@@ -227,7 +225,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         $vars[$key] = $value;
       }
 
-      foreach ($webserver_stack as $php => $workflow) {
+      foreach ($webserver_stack as $php => $drupal_pgsql) {
         $row = [];
         $badge = [];
 
@@ -237,9 +235,14 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         $vars['drupal'] = '';
         $vars['pgsql'] = '';
 
-        foreach ($workflow as $drupal => $pgsql) {
+        foreach ($strategy_matrix[self::WORKFLOW_VERSION['drupal']] as $drupal) {
+          if (!isset($drupal_pgsql[$drupal])) {
+            $row[$drupal] = '';
+            continue;
+          }
+
           // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
-          $grid = '[Grid' . str_replace('.', '', $php) . '-' . str_replace(['.', 'x-dev'], '', $drupal) . '-Badge]';
+          $grid = '[Grid' . str_replace('.', '', (string) $php) . '-' . str_replace(['.', 'x-dev'], '', (string) $drupal) . '-Badge]';
           $filename = sprintf('MAIN-phpunit-%s.yml', 'php' . $php . '_D' . $drupal);
 
           $row[$drupal] = '!' . $grid;
@@ -255,7 +258,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
 
           $vars['php'] = $php;
           $vars['drupal'] = $drupal;
-          $vars['pgsql'] = max($pgsql);
+          $vars['pgsql'] = max($drupal_pgsql[$drupal]);
 
           if (!file_exists($this->getTemplatePath() . DIRECTORY_SEPARATOR . self::WORKFLOW_TEMPLATE)) {
             throw new \Exception('Workflow template file does not exist.');

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -50,13 +50,19 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
   /**
    * Workflow configuration values.
    *
+   * Each key corresponds to a config key in the template file.
+   * @see /templates/tripal_admin/readme-grid-workflow.twig
+   *
    * @var string
    */
   private const WORKFLOW_OPTION = [
     'name' => 'PHPUnit',
-    'branch' => '4.x',
-    'branches' => 'tv4g0-issue2247-support-php-8.4',
+    'branches' => [
+      '4.x',
+      'tv4g0-issue2247-support-php-8.4'
+    ],
     'cron' => '0 6 * * *',
+    'test' => 'running-tests',
     'checkout' => 'actions/checkout@v4',
     'run' => 'tripal/test-tripal-action@v1.7',
   ];
@@ -75,6 +81,8 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
 
     $ir = $this->createInterviewer($vars);
     $machine_name = $ir->askMachineName();
+
+    // Must have this key.
     $vars['machine_name'] = $machine_name;
 
     $module = \Drupal::service('module_handler')
@@ -211,11 +219,23 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       $grid_header = array_merge(['PHP\Drupal'], $strategy_matrix[self::WORKFLOW_VERSION['drupal']]);
       $grid_rows = [];
 
+      // Setup workflow template static values.
+      $vars['module_directory_name'] = basename($module->getPath());
+      $vars['apply_module'] = implode(', ', $apply_module);
+
+      foreach (self::WORKFLOW_OPTION as $key => $value) {
+        $vars[$key] = $value;
+      }
+
       foreach ($webserver_stack as $php => $workflow) {
         $row = [];
         $badge = [];
 
         $row[$grid_header[0]] = '**PHP' . $php . '**';
+
+        $vars['php'] = '';
+        $vars['drupal'] = '';
+        $vars['pgsql'] = '';
 
         foreach ($workflow as $drupal => $pgsql) {
           // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
@@ -229,21 +249,13 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             $module->getName(),
             'actions',
             'workflows',
-            $filename ?? '',
+            $filename,
             'badge.svg',
           ]);
-
-          $vars['module_directory_name'] = basename($module->getPath());
-          $vars['apply_module'] = implode(', ', $apply_module);
 
           $vars['php'] = $php;
           $vars['drupal'] = $drupal;
           $vars['pgsql'] = max($pgsql);
-
-          $vars['branches'] = self::WORKFLOW_OPTION['branches'];
-          $vars['cron'] = self::WORKFLOW_OPTION['cron'];
-          $vars['checkout'] = self::WORKFLOW_OPTION['checkout'];
-          $vars['run'] = self::WORKFLOW_OPTION['run'];
 
           if (!file_exists($this->getTemplatePath() . DIRECTORY_SEPARATOR . self::WORKFLOW_TEMPLATE)) {
             throw new \Exception('Workflow template file does not exist.');
@@ -269,7 +281,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         ->render();
 
       // Exclusion notes.
-      if ($vars['exclusion_note']) {
+      if ($exclusion_note) {
         $this->io()->writeln(PHP_EOL);
         foreach ($exclusion_note as $note) {
           $this->io()->writeln($note . PHP_EOL);

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -91,7 +91,10 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       throw new \Exception('Module does not exist.');
     }
 
-    $phpunit_yml = '%s' . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE;
+    $phpunit_yml = self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE;
+    $this->io()->note("We use the PHPUnit matrixed workflow to determine the combinations being tested.");
+    $this->io()->note("Specifically, we expect there to be a Github Workflow ($phpunit_yml) with the 'jobs.run-tests.strategy.matrix' defined.");
+    $phpunit_yml = '%s' . DIRECTORY_SEPARATOR . $phpunit_yml;
 
     $module_path = $module->getPath();
     $module_phpunit = sprintf($phpunit_yml, $module_path);

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -116,7 +116,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
 
     if ($is_package) {
       // Confirm that it is a package.
-      $confirm_is_package = $ir->confirm('The module is a package, and the generator located the GitHub Workflow in the parent directory: ' . $module_path . ' and not in ' . $module->getPath() . '. Is the module a package?', TRUE);
+      $confirm_is_package = $ir->confirm('We located the GitHub Workflow in the parent directory: ' . $module_path . ' and not in ' . $module->getPath() . ', which implies this module is part of a package (i.e. multiple modules in a single repository). Is the module part of a package?', TRUE);
 
       if (!$confirm_is_package) {
         throw new \Exception('Could not find the workflow directory. Ensure that you have setup the directory .github/workflows/ in the module path and retry the command.');

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -242,10 +242,25 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             continue;
           }
 
-          // Php PHP VER _D DRUPAL VER (ie. php81_D104.x-dev).
-          $grid = '[Grid' . str_replace('.', '', (string) $php) . '-' . str_replace(['.', 'x-dev'], '', (string) $drupal) . '-Badge]';
-          // Php PHP VER _D DRUPAL VER (ie. php.1_D104x).
-          $filename = sprintf('MAIN-phpunit-%s.yml', 'php' . $php . '_D' . str_replace(['.', '-dev'], '', (string) $drupal));
+          // Simplified Drupal version.
+          // For example, "10_4x" for Drupal 10.4.x-dev
+          // or "10_45" for Drupal 10.4.5.
+          if (preg_match('/(\w+)\.(\w+)\.(\w+)(-dev)*/', (string) $drupal, $matches)) {
+            $drupal_simplified = $matches[1] . '_' . $matches[2] . $matches[3];
+          }
+          // For example, "11x" for Drupal 11.x-dev.
+          elseif (preg_match('/(\w+)\.x-dev/', (string) $drupal, $matches)) {
+            $drupal_simplified = $matches[1] . 'x';
+          }
+          else {
+            $drupal_simplified = str_replace(['.', '-dev'], '', (string) $drupal);
+          }
+          // Grid token used in the readme.
+          // For example, "Grid81-104-Badge" for PHP 8.1 and Drupal 10.4.x-dev.
+          $grid = '[Grid' . str_replace('.', '', (string) $php) . '-' . str_replace(['_', 'x'], '', (string) $drupal_simplified) . '-Badge]';
+          // Workflow filename.
+          // For example, "MAIN-phpunit-php8.1_D10_4x.yml" for the same combo.
+          $filename = 'MAIN-phpunit-php' . $php . '_D' . $drupal_simplified . '.yml';
 
           $row[$drupal] = '!' . $grid;
           $badge[$drupal] = $grid . ' : ' . implode(DIRECTORY_SEPARATOR, [

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -189,22 +189,21 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       foreach ($strategy_matrix['exclude'] as $exclude) {
         $php = $exclude[self::WORKFLOW_VERSION['php']] ?? 0;
         $drupal = $exclude[self::WORKFLOW_VERSION['drupal']];
+        $pgsql = $exclude[self::WORKFLOW_VERSION['pgsql']] ?? 0;
 
         if (!$php) {
           // Short hand instruction without PHP, will exclude all Drupal version
           // for every PHP version in the strategy.
           foreach ($strategy_matrix[self::WORKFLOW_VERSION['php']] as $php) {
-            unset($webserver_stack[$php][$drupal]);
-            $exclusion_note[] = '## PHP ' . $php . ' - Drupal ' . $drupal;
+            unset($webserver_stack[$php][$drupal][$pgsql]);
+            $exclusion_note[] = '## PHP ' . $php . ' - Drupal ' . $drupal . ' - PostgreSQL ' . $pgsql;
           }
 
           continue;
         }
 
-        $pgsql = $exclude[self::WORKFLOW_VERSION['pgsql']] ?? 0;
-
         if (isset($webserver_stack[$php]) && isset($webserver_stack[$php][$drupal])) {
-          if (isset($exclude[$pgsql])) {
+          if ($pgsql) {
             unset($webserver_stack[$php][$drupal][$pgsql]);
           }
           else {
@@ -274,6 +273,23 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         $grid_rows['badge'][] = $badge;
       }
 
+      // Allow the removal of specific grid column (Drupal header).
+      $header_choices = $grid_header;
+      $header_choices[0] = 'none - Keep all columns';
+      $col_remove = (int) $ir->choice(
+        'Select grid column header to remove',
+        array_values($header_choices),
+        $header_choices[0]
+      );
+
+      if ($col_remove) {
+        unset($grid_header[$col_remove]);
+
+        for ($i = 0; $i < count($grid_rows['grid']); $i++) {
+          unset($grid_rows['grid'][$i][$header_choices[$col_remove]]);
+        }
+      }
+
       // Table grid.
       // @see symfony.com/doc/current/components/console/helpers/table.html
       $this->io()->writeln(PHP_EOL . 'Copy and paste table grid below into README file.' . PHP_EOL);
@@ -283,9 +299,10 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         ->setRows($grid_rows['grid'])
         ->render();
 
-      // Exclusion notes.
+      // Exclude notes.
+      $this->io()->writeln(PHP_EOL);
       if ($exclusion_note) {
-        $this->io()->writeln(PHP_EOL);
+        $this->io()->writeln('Exclude notes:' . PHP_EOL);
         foreach ($exclusion_note as $note) {
           $this->io()->writeln($note . PHP_EOL);
         }

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -218,6 +218,16 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       $grid_header = array_merge(['PHP\Drupal'], $strategy_matrix[self::WORKFLOW_VERSION['drupal']]);
       $grid_rows = [];
 
+      // Allow the removal of specific grid column (Drupal header).
+      $header_choices = $grid_header;
+      $header_choices[0] = 'none - Keep all columns';
+
+      $col_remove = (int) $ir->choice(
+        'Select grid column header to remove',
+        array_values($header_choices),
+        $header_choices[0]
+      );
+
       // Setup workflow template static values.
       $vars['module_directory_name'] = basename($module->getPath());
       $vars['apply_module'] = implode(', ', $apply_module);
@@ -238,7 +248,13 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
 
         foreach ($strategy_matrix[self::WORKFLOW_VERSION['drupal']] as $drupal) {
           if (!isset($drupal_pgsql[$drupal])) {
+            // A shorthand.
             $row[$drupal] = '';
+            continue;
+          }
+
+          if ($col_remove && $header_choices[$col_remove] == $drupal) {
+            // Column to remove.
             continue;
           }
 
@@ -300,20 +316,12 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         $value->vars($temp_vars);
       }
 
-      // Allow the removal of specific grid column (Drupal header).
-      $header_choices = $grid_header;
-      $header_choices[0] = 'none - Keep all columns';
-      $col_remove = (int) $ir->choice(
-        'Select grid column header to remove',
-        array_values($header_choices),
-        $header_choices[0]
-      );
-
       if ($col_remove) {
         unset($grid_header[$col_remove]);
 
         for ($i = 0; $i < count($grid_rows['grid']); $i++) {
           unset($grid_rows['grid'][$i][$header_choices[$col_remove]]);
+          unset($grid_rows['badge'][$i][$header_choices[$col_remove]]);
         }
       }
 
@@ -327,13 +335,13 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         ->render();
 
       // Exclude notes.
-      $this->io()->writeln(PHP_EOL);
-      if ($exclusion_note) {
-        $this->io()->writeln('Exclude notes:' . PHP_EOL);
-        foreach ($exclusion_note as $note) {
-          $this->io()->writeln($note . PHP_EOL);
-        }
-      }
+      // $this->io()->writeln(PHP_EOL);
+      // if ($exclusion_note) {
+      //   $this->io()->writeln('Exclude notes:' . PHP_EOL);
+      //   foreach ($exclusion_note as $note) {
+      //     $this->io()->writeln($note . PHP_EOL);
+      //   }
+      // }.
 
       // Grid badges.
       $this->io()->writeln(PHP_EOL);

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -10,6 +10,8 @@ use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
  * Generate README grid.
@@ -17,17 +19,17 @@ use Symfony\Component\Yaml\Yaml;
 #[Generator(
   name: 'tripal-admin:readme-grid',
   description: 'Generates the Drupal by PHP version compatibility grid for the README and associated GitHub workflow files.',
-  templatePath: __DIR__ . '/../../../templates/generator/admin',
+  templatePath: __DIR__ . '/../../../templates/generator/tripal_admin',
   type: GeneratorType::MODULE_COMPONENT,
 )]
 final class AdminReadmeGridGenerator extends BaseGenerator {
 
   /**
-   * The module to work on.
+   * The test action to use.
    *
-   * @var Module Handler object
+   * @var string
    */
-  private $module;
+  private const WORKFLOW_ACTION = 'tripal/test-tripal-action@v1.7';
 
   /**
    * The main workflow file.
@@ -62,180 +64,192 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
     $ir = $this->createInterviewer($vars);
     $vars['machine_name'] = $ir->askMachineName();
 
-    $this->module = \Drupal::service('module_handler')
+    $module = \Drupal::service('module_handler')
       ->getModule($vars['machine_name']);
-    if (!$this->module) {
+    if (!$module) {
       throw new \Exception('Module does not exist.');
     }
 
-    $dir_path = $this->module->getPath();
-    if ($vars['machine_name'] == 'tripal') {
-      $dir_path = dirname($dir_path);
+    $phpunit_yml = '%s' . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE;
+
+    $module_path = $module->getPath();
+    $module_phpunit = sprintf($phpunit_yml, $module_path);
+
+    $is_package = FALSE;
+
+    if (!file_exists($module_phpunit)) {
+      // No workflow file asset in the module directory. Move one directory
+      // level up as it may likely be a package module.
+      $module_path = dirname($module_path, $one_level_up = 1);
+      $module_phpunit = sprintf($phpunit_yml, $module_path);
+
+      if (!file_exists($module_phpunit)) {
+        throw new \Exception('Failed to load the phpunit YML file of the module.');
+      }
+
+      $is_package = TRUE;
     }
 
-    $workflow_dir = $dir_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
+    $vars['module_apply'][] = $module->getName();
 
-    if (!is_dir($workflow_dir)) {
-      $new_workflow_dir = preg_replace('/' . $vars['machine_name'] . '$/', $workflow_dir);
+    if ($is_package) {
+      $sub_modules = [];
 
-      $workflow_dir = $new_workflow_dir . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
-      if (!is_dir($workflow_dir)) {
-        throw new \Exception('Failed to load workflow directory.');
+      foreach (scandir($module_path) as $sub_module) {
+        $sub_dir = $module_path . DIRECTORY_SEPARATOR . $sub_module;
+
+        // Exclude the module name entered in the beginning prompts.
+        if (is_dir($sub_dir) && !in_array($sub_module, ['.', '..', $module->getName()])) {
+
+          // Only directory with .info.yml (a module).
+          foreach (scandir($sub_dir) as $file) {
+            if (str_contains($file, '.info.yml')) {
+              array_push($sub_modules, $sub_module);
+              break;
+            }
+          }
+        }
+      }
+
+      // Prompt to ask which sub-modules the workflow apply.
+      $apply_all = $ir->confirm('The package module (Repository) has sub-modules. Apply workflow to all [' . implode(', ', $sub_modules) . '] (Yes) or select from list (No)', TRUE);
+
+      foreach ($sub_modules as $sub_module) {
+        $apply_to = '';
+
+        if ($apply_all) {
+          $apply_to = $sub_module;
+        }
+        else {
+          if ($ir->confirm('Apply workflow to sub-module: ' . $sub_module . '?', TRUE)) {
+            $apply_to = $sub_module;
+          }
+        }
+
+        if ($apply_to) {
+          $vars['module_apply'][] = $sub_module;
+        }
       }
     }
 
-    if (!file_exists($workflow_dir . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE)) {
-      throw new \Exception('Failed to load workflow ALL PHP Unit YML.');
-    }
-
     // Confirm removal of existing workflow files.
-    if ($ir->confirm('Delete existing workflow files before running this command.')) {
+    if ($ir->confirm('Delete existing workflow files before running this command.', TRUE)) {
 
-      $parse_build = Yaml::parseFile($workflow_dir . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE);
+      $parse_build = Yaml::parseFile($module_phpunit);
+
       $strategy_matrix = $parse_build['jobs']['run-tests']['strategy']['matrix'];
       if (empty($strategy_matrix)) {
         throw new \Exception('Failed to load workflow strategy matrix information.');
       }
 
-      $stack_matrix = [];
+      $webserver_stack = [];
 
-      // Create full technology stack.
+      // Create full tech stack.
       foreach ($strategy_matrix[self::WORKFLOW_VERSION['php']] as $php) {
         foreach ($strategy_matrix[self::WORKFLOW_VERSION['drupal']] as $drupal) {
           foreach ($strategy_matrix[self::WORKFLOW_VERSION['pgsql']] as $pgsql) {
-            $stack_matrix[$php][$drupal][] = $pgsql;
+            $webserver_stack[$php][$drupal][] = $pgsql;
           }
         }
       }
 
-      // Apply technology stack exclusions.
+      // Apply tech stack exclusion.
+      $vars['exclusion_note'] = [];
+
       foreach ($strategy_matrix['exclude'] as $exclude) {
-        $php = $exclude[self::WORKFLOW_VERSION['php']];
+        $php = $exclude[self::WORKFLOW_VERSION['php']] ?? 0;
         $drupal = $exclude[self::WORKFLOW_VERSION['drupal']];
+
+        if (!$php) {
+          // Short hand instruction without PHP, will exclude all Drupal version
+          // for every PHP version in the strategy.
+
+          foreach ($strategy_matrix[self::WORKFLOW_VERSION['php']] as $php) {
+            foreach ($strategy_matrix[self::WORKFLOW_VERSION['pgsql']] as $pgsql) {
+              unset($webserver_stack[$php][$drupal][$pgsql]);
+            }
+
+            $vars['exclusion_note'][] = '## PHP ' . $php . ' - Drupal ' . $drupal;
+          }
+
+          continue;
+        }
+
         $pgsql = $exclude[self::WORKFLOW_VERSION['pgsql']] ?? 0;
 
-        if (isset($stack_matrix[$php]) && isset($stack_matrix[$php][$drupal])) {
+        if (isset($webserver_stack[$php]) && isset($webserver_stack[$php][$drupal])) {
           if (isset($exclude[$pgsql])) {
-            unset($stack_matrix[$php][$drupal][$pgsql]);
+            unset($webserver_stack[$php][$drupal][$pgsql]);
           }
           else {
-            unset($stack_matrix[$php][$drupal]);
+            unset($webserver_stack[$php][$drupal]);
           }
         }
       }
 
       // Create workflow grid file.
-      $filename_scheme = 'MAIN-phpunit-%s.yml';
-
       $grid_header = array_merge(['PHP\Drupal'], $strategy_matrix[self::WORKFLOW_VERSION['drupal']]);
       $grid_rows = [];
 
-      $seq_num = 1;
-      foreach ($stack_matrix as $php => $workflow) {
+      foreach ($webserver_stack as $php => $workflow) {
         $row = [];
+        $badge = [];
+
         $row[$grid_header[0]] = '**PHP' . $php . '**';
 
-        $seq_char = 0;
         foreach ($workflow as $drupal => $pgsql) {
-          if ($this->module->getName() == 'tripal') {
             // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
-            $grid = str_replace('.', '', $php) . '-' . str_replace(['.', 'x-dev'], '', $drupal);
-            $filename = sprintf($filename_scheme, 'php' . $php . '_D' . $drupal);
-          }
-          else {
-            // Grid SEQUENCE # SEQUENCE CHAR A-Z (ie. Grid1A).
-            $grid = $seq_num . chr(65 + (int) $seq_char);
-            $filename = sprintf($filename_scheme, $grid);
-            $seq_char++;
-          }
+          $grid = '[Grid' . str_replace('.', '', $php) . '-' . str_replace(['.', 'x-dev'], '', $drupal) . '-Badge]';
+          $filename = sprintf('MAIN-phpunit-%s.yml', 'php' . $php . '_D' . $drupal);
 
-          $workflow_file_config = $this->composeWorkflowFileConfig(
-            $php,
-            $drupal, max($pgsql),
-            [
-              'branches' => 'g0.88-updateTestingMatrix',
-              'uses' => 'g0.88-updateTestingMatrix',
-            ],
-          );
-
-          file_put_contents(
-            $workflow_dir . DIRECTORY_SEPARATOR . $filename,
-            $workflow_file_config
-          );
-
-          $row[$drupal] = '![Grid' . $grid . '-Badge]';
+          $row[$drupal] = '!' . $grid;
+          $badge[$drupal] = $grid . ' : ' . implode(DIRECTORY_SEPARATOR, [
+            'https://github.com',
+            $module->getName(),
+            $module->getName(),
+            'actions',
+            'workflows',
+            $filename ?? '',
+            'badge.svg'
+          ]);
         }
 
-        $grid_rows[] = $row;
-        $seq_num++;
+        $grid_rows['grid'][] = $row;
+        $grid_rows['badge'][] = $badge;
       }
 
-      // Output the grid.
+      // Table grid.
       // @see symfony.com/doc/current/components/console/helpers/table.html
-      $this->io()->writeln("\n Copy and paste table grid below into README file. \n");
+      $this->io()->writeln(PHP_EOL . 'Copy and paste table grid below into README file.' . PHP_EOL);
       $table_grid = new Table($this->io()->getOutput());
       $table_grid
         ->setHeaders($grid_header)
-        ->setRows($grid_rows)
+        ->setRows($grid_rows['grid'])
         ->render();
-      $this->io()->writeln("\n");
+
+      // Exclusion notes.
+      if ($vars['exclusion_note']) {
+        $this->io()->writeln(PHP_EOL);
+        foreach ($vars['exclusion_note'] as $note) {
+          $this->io()->writeln($note . PHP_EOL);
+        }
+      }
+
+      // Grid badges.
+      $this->io()->writeln(PHP_EOL);
+      foreach ($grid_rows['badge'] as $rows) {
+        foreach ($rows as $badge) {
+          $this->io()->writeln($badge . PHP_EOL);
+        }
+      }
+
+      //
     }
     else {
-      // Existed the command.
       $this->io()->writeln('Exited workflow grid generator.');
     }
-  }
 
-  /**
-   * Create a workflow test job YML entries.
-   *
-   * @param string $php
-   *   The version of PHP.
-   * @param string $drupal
-   *   The version of Drupal.
-   * @param string $pgsql
-   *   The version of PostgreSQL.
-   * @param array $options
-   *   Additional values passed to workflow configuration.
-   *
-   * @return string
-   *   Workflow grid YML configuration.
-   */
-  public function composeWorkflowFileConfig(string $php, string $drupal, string $pgsql, array $options): string {
-
-    $module_name = $this->module->getName();
-    $module_base = basename($this->module->getPath());
-
-    $workflow_config = <<<WORKFLOW_CONFIG
-    name: PHPUnit
-    on:
-      push:
-        branches:
-          - 4.x
-          - {$options['branches']}
-      workflow_dispatch:
-      schedule:
-        - cron: '0 4 * * *'
-    jobs:
-      running-tests:
-        name: "Drupal {$drupal} - PHP {$php} - PostgreSQL {$pgsql}"
-        runs-on: ubuntu-latest
-        steps:
-          - name: Checkout Repository
-            uses: actions/checkout@v4
-          - name: Run Automated testing
-            uses: {$options['uses']}
-            with:
-              directory-name: '{$module_base}'
-              modules: '{$module_name}'
-              build-image: TRUE
-              dockerfile: 'Dockerfile'
-              php-version: '{$php}'
-              pgsql-version: '{$pgsql}'
-              drupal-version: '{$drupal}'
-    WORKFLOW_CONFIG;
-
-    return $workflow_config;
+    // Generate grid and workflow phpunit file.
   }
 
 }

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -149,9 +149,18 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             $seq_char++;
           }
 
+          $workflow_file_config = $this->composeWorkflowFileConfig(
+            $php,
+            $drupal, max($pgsql),
+            [
+              'branches' => 'g0.88-updateTestingMatrix',
+              'uses' => 'g0.88-updateTestingMatrix',
+            ],
+          );
+
           file_put_contents(
             $workflow_dir . DIRECTORY_SEPARATOR . $filename,
-            $this->composeWorkflowFileConfig($php, $drupal, max($pgsql))
+            $workflow_file_config
           );
 
           $row[$drupal] = '![Grid' . $grid . '-Badge]';
@@ -186,14 +195,13 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
    *   The version of Drupal.
    * @param string $pgsql
    *   The version of PostgreSQL.
+   * @param array $options
+   *   Additional values passed to workflow configuration.
    *
    * @return string
    *   Workflow grid YML configuration.
    */
-  public function composeWorkflowFileConfig(string $php, string $drupal, string $pgsql): string {
-
-    $branches = 'g0.88-updateTestingMatrix';
-    $uses = 'g0.88-updateTestingMatrix';
+  public function composeWorkflowFileConfig(string $php, string $drupal, string $pgsql, array $options): string {
 
     $module_name = $this->module->getName();
     $module_base = basename($this->module->getPath());
@@ -204,7 +212,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       push:
         branches:
           - 4.x
-          - {$branches}
+          - {$options['branches']}
       workflow_dispatch:
       schedule:
         - cron: '0 4 * * *'
@@ -216,7 +224,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
           - name: Checkout Repository
             uses: actions/checkout@v4
           - name: Run Automated testing
-            uses: {$uses}
+            uses: {$options['uses']}
             with:
               directory-name: '{$module_base}'
               modules: '{$module_name}'

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -144,7 +144,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       }
 
       // Prompt to ask which sub-modules the workflow apply.
-      $apply_all = $ir->confirm('The package module (Repository) has sub-modules. Apply workflow to all [' . implode(', ', $sub_modules) . '] (Yes) or select from list (No)', TRUE);
+      $apply_all = $ir->confirm('The package module (Repository) has sub-modules. Apply workflow to all [' . implode(', ', array_merge([$machine_name], $sub_modules)) . '] (Yes) or select from list (No)', TRUE);
 
       foreach ($sub_modules as $sub_module) {
         $apply_to = '';

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -60,7 +60,6 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
     'name' => 'PHPUnit',
     'branches' => [
       '4.x',
-      'tv4g0-issue2247-support-php-8.4',
     ],
     'cron' => '0 6 * * *',
     'test' => 'running-tests',

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -212,6 +212,11 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             $filename ?? '',
             'badge.svg'
           ]);
+
+          $assets->addFile(
+            $module_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . $filename,
+            'readme-grid-workflow.twig'
+          );
         }
 
         $grid_rows['grid'][] = $row;

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -8,6 +8,7 @@ use DrupalCodeGenerator\Asset\AssetCollection as Assets;
 use DrupalCodeGenerator\Attribute\Generator;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -20,6 +21,13 @@ use Symfony\Component\Yaml\Yaml;
   type: GeneratorType::MODULE_COMPONENT,
 )]
 final class AdminReadmeGridGenerator extends BaseGenerator {
+
+  /**
+   * The module to work on.
+   *
+   * @var Module Handler object
+   */
+  private $module;
 
   /**
    * The main workflow file.
@@ -36,13 +44,13 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
   private const WORKFLOW_DIR = '.github/workflows';
 
   /**
-   * Workflow YML keys.
+   * Workflow stack version YML keys.
    *
    * @var array
    */
-  private const WORKFLOW_VER_KEY = [
-    'drupal' => 'drupal-version',
+  private const WORKFLOW_VERSION = [
     'php' => 'php-version',
+    'drupal' => 'drupal-version',
     'pgsql' => 'pgsql-version',
   ];
 
@@ -50,79 +58,159 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
    * {@inheritdoc}
    */
   protected function generate(array &$vars, Assets $assets): void {
-    $ir = $this->createInterviewer($vars);
 
+    $ir = $this->createInterviewer($vars);
     $vars['machine_name'] = $ir->askMachineName();
 
-    $module_path = \Drupal::service('module_handler')
-      ->getModule($vars['machine_name'])
-      ->getPath();
-
-    $module_workflow = $module_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
-    if (is_dir($module_workflow)) {
-      $assets = array_diff(scandir($module_workflow), ['.', '..']);
-
-      $sample = array_filter($assets, function ($a) {
-        return strpos($a, 'MAIN-phpunit') !== FALSE;
-      });
-
-      $conv = str_contains(strtolower(current($sample)), 'grid') ? 'grid' : 'version';
-
+    $this->module = \Drupal::service('module_handler')
+      ->getModule($vars['machine_name']);
+    if (!$this->module) {
+      throw new \Exception('Module does not exist.');
     }
 
-    // Confirm removal of existing grid.
-    if ($ir->confirm('Ensure that you have deleted any existing workflow grid before running this command.')) {
-      $parse_build = Yaml::parseFile($module_workflow . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE);
+    $workflow_dir = $this->module->getPath() . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
+    if (!is_dir($workflow_dir)) {
+      throw new \Exception('Failed to load workflow directory.');
+    }
 
+    // Confirm removal of existing workflow files.
+    if ($ir->confirm('Delete existing workflow files before running this command.')) {
+
+      $parse_build = Yaml::parseFile($workflow_dir . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE);
       $strategy_matrix = $parse_build['jobs']['run-tests']['strategy']['matrix'];
+      if (empty($strategy_matrix)) {
+        throw new \Exception('Failed to load workflow strategy matrix information.');
+      }
 
-      $php_stack = $strategy_matrix[self::WORKFLOW_VER_KEY['php']];
-      $drupal_stack = $strategy_matrix[self::WORKFLOW_VER_KEY['drupal']];
-      $pgsql_stack = $strategy_matrix[self::WORKFLOW_VER_KEY['pgsql']];
+      $stack_matrix = [];
 
-      $matrix = [];
-      foreach ($php_stack as $include_php) {
-        foreach ($drupal_stack as $include_drupal) {
-          foreach ($pgsql_stack as $include_pgsql) {
-            $matrix[$include_php][$include_drupal][] = $include_pgsql;
+      // Create full technology stack.
+      foreach ($strategy_matrix[self::WORKFLOW_VERSION['php']] as $php) {
+        foreach ($strategy_matrix[self::WORKFLOW_VERSION['drupal']] as $drupal) {
+          foreach ($strategy_matrix[self::WORKFLOW_VERSION['pgsql']] as $pgsql) {
+            $stack_matrix[$php][$drupal][] = $pgsql;
           }
         }
       }
 
+      // Apply technology stack exclusions.
       foreach ($strategy_matrix['exclude'] as $exclude) {
-        $php = $exclude[self::WORKFLOW_VER_KEY['php']];
-        $drupal = $exclude[self::WORKFLOW_VER_KEY['drupal']];
-        $pgsql = $exclude[self::WORKFLOW_VER_KEY['pgsql']] ?? 0;
+        $php = $exclude[self::WORKFLOW_VERSION['php']];
+        $drupal = $exclude[self::WORKFLOW_VERSION['drupal']];
+        $pgsql = $exclude[self::WORKFLOW_VERSION['pgsql']] ?? 0;
 
-        if (isset($matrix[$php]) && isset($matrix[$php][$drupal])) {
+        if (isset($stack_matrix[$php]) && isset($stack_matrix[$php][$drupal])) {
           if (isset($exclude[$pgsql])) {
-            unset($matrix[$php][$drupal][$pgsql]);
+            unset($stack_matrix[$php][$drupal][$pgsql]);
           }
           else {
-            unset($matrix[$php][$drupal]);
+            unset($stack_matrix[$php][$drupal]);
           }
         }
       }
-    }
 
-    $seq_num = 1;
-    foreach ($matrix as $php_ver => $workflow) {
-      $seq_char = 0;
+      // Create workflow grid file.
+      $filename_scheme = 'MAIN-phpunit-%s.yml';
 
-      foreach ($workflow as $drupal_ver => $_) {
-        if ($conv == 'grid') {
-          $filename = 'MAIN-phpunit-Grid' . $seq_num . chr(65 + (int) $seq_char) . '.yml';
-          $seq_char++;
+      $grid_header = ['PHP/Drupal'] + $strategy_matrix[self::WORKFLOW_VERSION['drupal']];
+      $grid_rows = [];
+
+      $seq_num = 1;
+      foreach ($stack_matrix as $php => $workflow) {
+        $row = [];
+        $row[$grid_header[0]] = '**PHP' . $php . '**';
+
+        $seq_char = 0;
+        foreach ($workflow as $drupal => $pgsql) {
+          if ($this->module->getName() == 'tripal') {
+            // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
+            $grid = str_replace('.', '', $php) . '-' . str_replace(['.', 'x-dev'], '', $drupal);
+            $filename = sprintf($filename_scheme, 'php' . $php . '_D' . $drupal);
+          }
+          else {
+            // Grid SEQUENCE # SEQUENCE CHAR A-Z (ie. Grid1A).
+            $grid = $seq_num . chr(65 + (int) $seq_char);
+            $filename = sprintf($filename_scheme, $grid);
+            $seq_char++;
+          }
+
+          file_put_contents(
+            $workflow_dir . DIRECTORY_SEPARATOR . $filename,
+            $this->composeWorkflowFileConfig($php, $drupal, max($pgsql))
+          );
+
+          $row[$drupal] = '![Grid' . $grid . '-Badge]';
         }
-        else {
-          $filename = 'MAIN-phpunit-php' . $php_ver . '_D' . $drupal_ver . '.yml';
-        }
 
-        file_put_contents($module_workflow . DIRECTORY_SEPARATOR . 'TEMP' . $filename, 'ABC');
+        $grid_rows[] = $row;
+        $seq_num++;
       }
 
-      $seq_num++;
+      // Output the grid.
+      // @see symfony.com/doc/current/components/console/helpers/table.html
+      $this->io()->writeln('Copy and paste table grid below into README file.');
+      $table_grid = new Table($this->io()->getOutput());
+      $table_grid
+        ->setHeaders($grid_header)
+        ->setRows($grid_rows)
+        ->render();
     }
+
+    // Existed the command.
+    $this->io()->writeln('Exited workflow grid generator.');
+  }
+
+  /**
+   * Create a workflow test job YML entries.
+   *
+   * @param string $php
+   *   The version of PHP.
+   * @param string $drupal
+   *   The version of Drupal.
+   * @param string $pgsql
+   *   The version of PostgreSQL.
+   *
+   * @return string
+   *   Workflow grid YML configuration.
+   */
+  public function composeWorkflowFileConfig(string $php, string $drupal, string $pgsql): string {
+
+    $branches = 'g0.88-updateTestingMatrix';
+    $uses = 'g0.88-updateTestingMatrix';
+
+    $module_name = $this->module->getName();
+    $module_base = basename($this->module->getPath());
+
+    $workflow_config = <<<WORKFLOW_CONFIG
+    name: PHPUnit
+    on:
+      push:
+        branches:
+          - 4.x
+          - {$branches}
+      workflow_dispatch:
+      schedule:
+        - cron: '0 4 * * *'
+    jobs:
+      running-tests:
+        name: "Drupal {$drupal} - PHP {$php} - PostgreSQL {$pgsql}"
+        runs-on: ubuntu-latest
+        steps:
+          - name: Checkout Repository
+            uses: actions/checkout@v4
+          - name: Run Automated testing
+            uses: {$uses}
+            with:
+              directory-name: '{$module_base}'
+              modules: '{$module_name}'
+              build-image: TRUE
+              dockerfile: 'Dockerfile'
+              php-version: '{$php}'
+              pgsql-version: '{$pgsql}'
+              drupal-version: '{$drupal}'
+    WORKFLOW_CONFIG;
+
+    return $workflow_config;
   }
 
 }

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -223,15 +223,15 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         $vars[$key] = $value;
       }
 
+      if (!file_exists($this->getTemplatePath() . DIRECTORY_SEPARATOR . self::WORKFLOW_TEMPLATE)) {
+        throw new \Exception('Workflow template file does not exist.');
+      }
+
       foreach ($webserver_stack as $php => $drupal_pgsql) {
         $row = [];
         $badge = [];
 
         $row[$grid_header[0]] = '**PHP' . $php . '**';
-
-        $vars['php'] = '';
-        $vars['drupal'] = '';
-        $vars['pgsql'] = '';
 
         foreach ($strategy_matrix[self::WORKFLOW_VERSION['drupal']] as $drupal) {
           if (!isset($drupal_pgsql[$drupal])) {
@@ -239,9 +239,10 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             continue;
           }
 
-          // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
+          // Php PHP VER _D DRUPAL VER (ie. php81_D104.x-dev).
           $grid = '[Grid' . str_replace('.', '', (string) $php) . '-' . str_replace(['.', 'x-dev'], '', (string) $drupal) . '-Badge]';
-          $filename = sprintf('MAIN-phpunit-%s.yml', 'php' . $php . '_D' . $drupal);
+          // Php PHP VER _D DRUPAL VER (ie. php.1_D104x).
+          $filename = sprintf('MAIN-phpunit-%s.yml', 'php' . $php . '_D' . str_replace(['.', '-dev'], '', (string) $drupal));
 
           $row[$drupal] = '!' . $grid;
           $badge[$drupal] = $grid . ' : ' . implode(DIRECTORY_SEPARATOR, [
@@ -254,22 +255,31 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             'badge.svg',
           ]);
 
-          $vars['php'] = $php;
-          $vars['drupal'] = $drupal;
-          $vars['pgsql'] = max($drupal_pgsql[$drupal]);
-
-          if (!file_exists($this->getTemplatePath() . DIRECTORY_SEPARATOR . self::WORKFLOW_TEMPLATE)) {
-            throw new \Exception('Workflow template file does not exist.');
-          }
+          // In twig - stack[filename].php/drupal/pgsql.
+          // @see assets loop below about filename.
+          $vars['stack'][$filename] = [
+            'php' => $php,
+            'drupal' => $drupal,
+            'pgsql' => max($drupal_pgsql[$drupal]),
+          ];
 
           $assets->addFile(
             (($is_package) ? '../' : '/') . self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . $filename,
-            self::WORKFLOW_TEMPLATE
+            self::WORKFLOW_TEMPLATE,
           );
         }
 
         $grid_rows['grid'][] = $row;
         $grid_rows['badge'][] = $badge;
+      }
+
+      // Inject the filename into the vars for each addFile() call.
+      // The filename is then used to reference which php-drupal-pgsql combo
+      // to encode into the yml file.
+      foreach ($assets as $value) {
+        $temp_vars = $value->getVars();
+        $temp_vars['filename'] = trim(str_replace([self::WORKFLOW_DIR, '/', '..'], '', $value->getPath()));
+        $value->vars($temp_vars);
       }
 
       // Allow the removal of specific grid column (Drupal header).

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -10,8 +10,6 @@ use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Yaml\Yaml;
-use Symfony\Component\Console\Helper\QuestionHelper;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 
 /**
  * Generate README grid.
@@ -23,13 +21,6 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
   type: GeneratorType::MODULE_COMPONENT,
 )]
 final class AdminReadmeGridGenerator extends BaseGenerator {
-
-  /**
-   * The test action to use.
-   *
-   * @var string
-   */
-  private const WORKFLOW_ACTION = 'tripal/test-tripal-action@v1.7';
 
   /**
    * The main workflow file.
@@ -57,15 +48,37 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
   ];
 
   /**
+   * Workflow configuration values.
+   *
+   * @var string
+   */
+  private const WORKFLOW_OPTION = [
+    'name' => 'PHPUnit',
+    'branch' => '4.x',
+    'branches' => 'tv4g0-issue2247-support-php-8.4',
+    'cron' => '0 6 * * *',
+    'checkout' => 'actions/checkout@v4',
+    'run' => 'tripal/test-tripal-action@v1.7',
+  ];
+
+  /**
+   * The workflow template file.
+   *
+   * @var string
+   */
+  private const WORKFLOW_TEMPLATE = 'readme-grid-workflow.twig';
+
+  /**
    * {@inheritdoc}
    */
   protected function generate(array &$vars, Assets $assets): void {
 
     $ir = $this->createInterviewer($vars);
-    $vars['machine_name'] = $ir->askMachineName();
+    $machine_name = $ir->askMachineName();
+    $vars['machine_name'] = $machine_name;
 
     $module = \Drupal::service('module_handler')
-      ->getModule($vars['machine_name']);
+      ->getModule($machine_name);
     if (!$module) {
       throw new \Exception('Module does not exist.');
     }
@@ -90,9 +103,17 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       $is_package = TRUE;
     }
 
-    $vars['module_apply'][] = $module->getName();
+    $apply_module = [];
+    $apply_module[] = $module->getName();
 
     if ($is_package) {
+      // Confirm that it is a package.
+      $confirm_is_package = $ir->confirm('The module is a package, and the generator located the GitHub Workflow in the parent directory: ' . $module_path . ' and not in ' . $module->getPath() . '. Is the module a package?', TRUE);
+
+      if (!$confirm_is_package) {
+        throw new \Exception('Could not find the workflow directory. Ensure that you have setup the directory .github/workflows/ in the module path and retry the command.');
+      }
+
       $sub_modules = [];
 
       foreach (scandir($module_path) as $sub_module) {
@@ -127,7 +148,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         }
 
         if ($apply_to) {
-          $vars['module_apply'][] = $sub_module;
+          $apply_module[] = $sub_module;
         }
       }
     }
@@ -154,7 +175,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       }
 
       // Apply tech stack exclusion.
-      $vars['exclusion_note'] = [];
+      $exclusion_note = [];
 
       foreach ($strategy_matrix['exclude'] as $exclude) {
         $php = $exclude[self::WORKFLOW_VERSION['php']] ?? 0;
@@ -163,13 +184,12 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         if (!$php) {
           // Short hand instruction without PHP, will exclude all Drupal version
           // for every PHP version in the strategy.
-
           foreach ($strategy_matrix[self::WORKFLOW_VERSION['php']] as $php) {
             foreach ($strategy_matrix[self::WORKFLOW_VERSION['pgsql']] as $pgsql) {
               unset($webserver_stack[$php][$drupal][$pgsql]);
             }
 
-            $vars['exclusion_note'][] = '## PHP ' . $php . ' - Drupal ' . $drupal;
+            $exclusion_note[] = '## PHP ' . $php . ' - Drupal ' . $drupal;
           }
 
           continue;
@@ -198,7 +218,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         $row[$grid_header[0]] = '**PHP' . $php . '**';
 
         foreach ($workflow as $drupal => $pgsql) {
-            // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
+          // Php PHP VER _D DRUPAL VER (ie. php8.1_D10.4.x-dev).
           $grid = '[Grid' . str_replace('.', '', $php) . '-' . str_replace(['.', 'x-dev'], '', $drupal) . '-Badge]';
           $filename = sprintf('MAIN-phpunit-%s.yml', 'php' . $php . '_D' . $drupal);
 
@@ -210,12 +230,28 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
             'actions',
             'workflows',
             $filename ?? '',
-            'badge.svg'
+            'badge.svg',
           ]);
 
+          $vars['module_directory_name'] = basename($module->getPath());
+          $vars['apply_module'] = implode(', ', $apply_module);
+
+          $vars['php'] = $php;
+          $vars['drupal'] = $drupal;
+          $vars['pgsql'] = max($pgsql);
+
+          $vars['branches'] = self::WORKFLOW_OPTION['branches'];
+          $vars['cron'] = self::WORKFLOW_OPTION['cron'];
+          $vars['checkout'] = self::WORKFLOW_OPTION['checkout'];
+          $vars['run'] = self::WORKFLOW_OPTION['run'];
+
+          if (!file_exists($this->getTemplatePath() . DIRECTORY_SEPARATOR . self::WORKFLOW_TEMPLATE)) {
+            throw new \Exception('Workflow template file does not exist.');
+          }
+
           $assets->addFile(
-            $module_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . $filename,
-            'readme-grid-workflow.twig'
+            (($is_package) ? '../' : '/') . self::WORKFLOW_DIR . DIRECTORY_SEPARATOR . $filename,
+            self::WORKFLOW_TEMPLATE
           );
         }
 
@@ -235,7 +271,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       // Exclusion notes.
       if ($vars['exclusion_note']) {
         $this->io()->writeln(PHP_EOL);
-        foreach ($vars['exclusion_note'] as $note) {
+        foreach ($exclusion_note as $note) {
           $this->io()->writeln($note . PHP_EOL);
         }
       }
@@ -248,13 +284,12 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
         }
       }
 
-      //
+      // End confirm to continue.
     }
     else {
+
       $this->io()->writeln('Exited workflow grid generator.');
     }
-
-    // Generate grid and workflow phpunit file.
   }
 
 }

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -332,7 +332,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
     }
     else {
 
-      $this->io()->writeln('Exited workflow grid generator.');
+      $this->io()->writeln('Exited workflow grid generator. Please go delete the existing badge-focused workflow files (e.g. .github/workflows/MAIN-phpunit-VERSIONCOMBO.yml) and then run this command again.');
     }
   }
 

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\tripal_devtools\Drush\Generators;
+
+use DrupalCodeGenerator\Asset\AssetCollection as Assets;
+use DrupalCodeGenerator\Attribute\Generator;
+use DrupalCodeGenerator\Command\BaseGenerator;
+use DrupalCodeGenerator\GeneratorType;
+
+/**
+ * Generate README grid.
+ */
+#[Generator(
+  name: 'tripal-admin:readme-grid',
+  description: 'Generates the Drupal by PHP version compatibility grid for the README and associated GitHub workflow files.',
+  templatePath: __DIR__ . '/../../../templates/generator/admin',
+  type: GeneratorType::MODULE_COMPONENT,
+)]
+final class AdminReadmeGridGenerator extends BaseGenerator {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function generate(array &$vars, Assets $assets): void {
+    $ir = $this->createInterviewer($vars);
+
+    $vars['machine_name'] = $ir->askMachineName();
+    $vars['git_workflow'] = '.github/workflows/ALL-phpunit.yml';
+
+    // Confirm removal of existing grid.
+    if ($ir->confirm('Ensure that you have deleted any existing workflow grid before running this command.')) {
+      $module_path = \Drupal::service('module_handler')
+        ->getModule($vars['machine_name'])
+        ->getPath();
+
+      if (is_file($module_path . '/' . $vars['git_workflow'])) {
+
+        // $assets->addFile('src/{class}.php', 'readme-grid.twig');
+      }
+    }
+  }
+
+}

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -8,6 +8,7 @@ use DrupalCodeGenerator\Asset\AssetCollection as Assets;
 use DrupalCodeGenerator\Attribute\Generator;
 use DrupalCodeGenerator\Command\BaseGenerator;
 use DrupalCodeGenerator\GeneratorType;
+use Symfony\Component\Yaml\Yaml;
 
 /**
  * Generate README grid.
@@ -21,23 +22,98 @@ use DrupalCodeGenerator\GeneratorType;
 final class AdminReadmeGridGenerator extends BaseGenerator {
 
   /**
+   * The main workflow file.
+   *
+   * @var string
+   */
+  private const WORKFLOW_FILE = 'ALL-phpunit.yml';
+
+  /**
+   * The main workflow directory.
+   *
+   * @var string
+   */
+  private const WORKFLOW_DIR = '.github/workflows';
+
+  /**
+   * Workflow YML keys.
+   *
+   * @var array
+   */
+  private const WORKFLOW_VER_KEY = [
+    'drupal' => 'drupal-version',
+    'php' => 'php-version',
+    'pgsql' => 'pgsql-version',
+  ];
+
+  /**
    * {@inheritdoc}
    */
   protected function generate(array &$vars, Assets $assets): void {
     $ir = $this->createInterviewer($vars);
 
     $vars['machine_name'] = $ir->askMachineName();
-    $vars['git_workflow'] = '.github/workflows/ALL-phpunit.yml';
+
+    $module_path = \Drupal::service('module_handler')
+      ->getModule($vars['machine_name'])
+      ->getPath();
+
+    $module_workflow = $module_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
+    if (is_dir($module_workflow)) {
+      $assets = array_diff(scandir($module_workflow), ['.', '..']);
+      $sample = array_filter($assets, function ($a) {
+        return strpos($a, 'MAIN-phpunit') !== FALSE;
+      });
+
+      $conv = str_contains(current($sample), 'Grid') ? 'grid' : 'version';
+    }
 
     // Confirm removal of existing grid.
     if ($ir->confirm('Ensure that you have deleted any existing workflow grid before running this command.')) {
-      $module_path = \Drupal::service('module_handler')
-        ->getModule($vars['machine_name'])
-        ->getPath();
+      $parse_build = Yaml::parseFile($module_workflow . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE);
 
-      if (is_file($module_path . '/' . $vars['git_workflow'])) {
+      $strategy_matrix = $parse_build['jobs']['run-tests']['strategy']['matrix'];
 
-        // $assets->addFile('src/{class}.php', 'readme-grid.twig');
+      $php_stack = $strategy_matrix[self::WORKFLOW_VER_KEY['php']];
+      $drupal_stack = $strategy_matrix[self::WORKFLOW_VER_KEY['drupal']];
+      $pgsql_stack = $strategy_matrix[self::WORKFLOW_VER_KEY['pgsql']];
+
+      $matrix = [];
+      foreach ($php_stack as $include_php) {
+        foreach ($drupal_stack as $include_drupal) {
+          foreach ($pgsql_stack as $include_pgsql) {
+            $matrix[$include_php . $include_drupal . $include_pgsql] = [
+              $include_php,
+              $include_drupal,
+              $include_pgsql,
+            ];
+          }
+        }
+      }
+
+      foreach ($strategy_matrix['exclude'] as $exclude) {
+        $key = $exclude[self::WORKFLOW_VER_KEY['php']] . $exclude[self::WORKFLOW_VER_KEY['drupal']];
+
+        if (isset($exclude[self::WORKFLOW_VER_KEY['pgsql']])) {
+          unset($matrix[$key . $exclude[self::WORKFLOW_VER_KEY['pgsql']]]);
+        }
+        else {
+          foreach ($pgsql_stack as $pgsql_ver) {
+            if (isset($matrix[$key . $pgsql_ver])) {
+              unset($matrix[$key . $pgsql_ver]);
+            }
+          }
+        }
+      }
+
+      $i = 1;
+      foreach ($matrix as $workflow) {
+        $filename = ($conv == 'grid')
+          ? 'MAIN-phpunit-Grid' . $i . chr(65 + (int) ($i - 1)) . '.yml'
+          : 'MAIN-phpunit-php' . $workflow[0] . '_D' . $workflow[1] . '.yml';
+
+        file_put_contents($module_workflow . DIRECTORY_SEPARATOR . 'TEMP' . $filename, 'ABC');
+        $i++;
       }
     }
   }

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -165,7 +165,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
     }
 
     // Confirm removal of existing workflow files.
-    if ($ir->confirm('Delete existing workflow files before running this command.', TRUE)) {
+    if ($ir->confirm('This command expects the existing badge-focused workflow files (e.g. .github/workflows/MAIN-phpunit-VERSIONCOMBO.yml) to be deleted already. Have you deleted them?', TRUE)) {
 
       $parse_build = Yaml::parseFile($module_phpunit);
 

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -68,9 +68,24 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       throw new \Exception('Module does not exist.');
     }
 
-    $workflow_dir = $this->module->getPath() . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
+    $dir_path = $this->module->getPath();
+    if ($vars['machine_name'] == 'tripal') {
+      $dir_path = dirname($dir_path);
+    }
+
+    $workflow_dir = $dir_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
+
     if (!is_dir($workflow_dir)) {
-      throw new \Exception('Failed to load workflow directory.');
+      $new_workflow_dir = preg_replace('/' . $vars['machine_name'] . '$/', $workflow_dir);
+
+      $workflow_dir = $new_workflow_dir . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
+      if (!is_dir($workflow_dir)) {
+        throw new \Exception('Failed to load workflow directory.');
+      }
+    }
+
+    if (!file_exists($workflow_dir . DIRECTORY_SEPARATOR . self::WORKFLOW_FILE)) {
+      throw new \Exception('Failed to load workflow ALL PHP Unit YML.');
     }
 
     // Confirm removal of existing workflow files.
@@ -112,7 +127,7 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       // Create workflow grid file.
       $filename_scheme = 'MAIN-phpunit-%s.yml';
 
-      $grid_header = ['PHP/Drupal'] + $strategy_matrix[self::WORKFLOW_VERSION['drupal']];
+      $grid_header = array_merge(['PHP\Drupal'], $strategy_matrix[self::WORKFLOW_VERSION['drupal']]);
       $grid_rows = [];
 
       $seq_num = 1;
@@ -148,16 +163,18 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
 
       // Output the grid.
       // @see symfony.com/doc/current/components/console/helpers/table.html
-      $this->io()->writeln('Copy and paste table grid below into README file.');
+      $this->io()->writeln("\n Copy and paste table grid below into README file. \n");
       $table_grid = new Table($this->io()->getOutput());
       $table_grid
         ->setHeaders($grid_header)
         ->setRows($grid_rows)
         ->render();
+      $this->io()->writeln("\n");
     }
-
-    // Existed the command.
-    $this->io()->writeln('Exited workflow grid generator.');
+    else {
+      // Existed the command.
+      $this->io()->writeln('Exited workflow grid generator.');
+    }
   }
 
   /**

--- a/src/Drush/Generators/AdminReadmeGridGenerator.php
+++ b/src/Drush/Generators/AdminReadmeGridGenerator.php
@@ -61,11 +61,13 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
     $module_workflow = $module_path . DIRECTORY_SEPARATOR . self::WORKFLOW_DIR;
     if (is_dir($module_workflow)) {
       $assets = array_diff(scandir($module_workflow), ['.', '..']);
+
       $sample = array_filter($assets, function ($a) {
         return strpos($a, 'MAIN-phpunit') !== FALSE;
       });
 
-      $conv = str_contains(current($sample), 'Grid') ? 'grid' : 'version';
+      $conv = str_contains(strtolower(current($sample)), 'grid') ? 'grid' : 'version';
+
     }
 
     // Confirm removal of existing grid.
@@ -82,39 +84,44 @@ final class AdminReadmeGridGenerator extends BaseGenerator {
       foreach ($php_stack as $include_php) {
         foreach ($drupal_stack as $include_drupal) {
           foreach ($pgsql_stack as $include_pgsql) {
-            $matrix[$include_php . $include_drupal . $include_pgsql] = [
-              $include_php,
-              $include_drupal,
-              $include_pgsql,
-            ];
+            $matrix[$include_php][$include_drupal][] = $include_pgsql;
           }
         }
       }
 
       foreach ($strategy_matrix['exclude'] as $exclude) {
-        $key = $exclude[self::WORKFLOW_VER_KEY['php']] . $exclude[self::WORKFLOW_VER_KEY['drupal']];
+        $php = $exclude[self::WORKFLOW_VER_KEY['php']];
+        $drupal = $exclude[self::WORKFLOW_VER_KEY['drupal']];
+        $pgsql = $exclude[self::WORKFLOW_VER_KEY['pgsql']] ?? 0;
 
-        if (isset($exclude[self::WORKFLOW_VER_KEY['pgsql']])) {
-          unset($matrix[$key . $exclude[self::WORKFLOW_VER_KEY['pgsql']]]);
-        }
-        else {
-          foreach ($pgsql_stack as $pgsql_ver) {
-            if (isset($matrix[$key . $pgsql_ver])) {
-              unset($matrix[$key . $pgsql_ver]);
-            }
+        if (isset($matrix[$php]) && isset($matrix[$php][$drupal])) {
+          if (isset($exclude[$pgsql])) {
+            unset($matrix[$php][$drupal][$pgsql]);
+          }
+          else {
+            unset($matrix[$php][$drupal]);
           }
         }
       }
+    }
 
-      $i = 1;
-      foreach ($matrix as $workflow) {
-        $filename = ($conv == 'grid')
-          ? 'MAIN-phpunit-Grid' . $i . chr(65 + (int) ($i - 1)) . '.yml'
-          : 'MAIN-phpunit-php' . $workflow[0] . '_D' . $workflow[1] . '.yml';
+    $seq_num = 1;
+    foreach ($matrix as $php_ver => $workflow) {
+      $seq_char = 0;
+
+      foreach ($workflow as $drupal_ver => $_) {
+        if ($conv == 'grid') {
+          $filename = 'MAIN-phpunit-Grid' . $seq_num . chr(65 + (int) $seq_char) . '.yml';
+          $seq_char++;
+        }
+        else {
+          $filename = 'MAIN-phpunit-php' . $php_ver . '_D' . $drupal_ver . '.yml';
+        }
 
         file_put_contents($module_workflow . DIRECTORY_SEPARATOR . 'TEMP' . $filename, 'ABC');
-        $i++;
       }
+
+      $seq_num++;
     }
   }
 

--- a/templates/generator/tripal_admin/readme-grid-workflow.twig
+++ b/templates/generator/tripal_admin/readme-grid-workflow.twig
@@ -1,29 +1,32 @@
-name: 'PHPUnit'
+{# Workflow Grid PHPUnit template file, saved in /.github/workflows/ of a module #}
+
+name: '{{ name }}'
 
 on:
   workflow_dispatch:
   push:
     branches:
-      - '4.x'
+      - '{{ branch }}'
       - '{{ branches }}'
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '{{ cron }}'
 
 permissions: read-all
 
 jobs:
   running-tests:
-    name: 'PHP {{ php }} : Drupal {{ drupal }}'
+    name: 'PHP {{ php }} - Drupal {{ drupal }} - PostgreSQL {{ pgsql }}'
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout Repository'
-        uses: 'actions/checkout@v4'
+        uses: '{{ checkout }}'
       - name: 'Run Automated testing'
-        uses: '{{ test_actions }}'
+        uses: '{{ run }}'
         with:
-          directory-name: {{ module_directory_name }}
-          modules: {{ apply_module }}
-          php-version: {{ php }}
-          drupal-version: {{ drupal }}
-          pgsql-version: {{ pgsql }}
-          build-image: true
+          directory-name: '{{ module_directory_name }}'
+          modules: '{{ apply_module }}'
+          php-version: '{{ php }}'
+          drupal-version: '{{ drupal }}'
+          pgsql-version: '{{ pgsql }}'
+          build-image: TRUE
+          dockerfile: 'Dockerfile'

--- a/templates/generator/tripal_admin/readme-grid-workflow.twig
+++ b/templates/generator/tripal_admin/readme-grid-workflow.twig
@@ -14,6 +14,10 @@ on:
 
 permissions: read-all
 
+{% set php = stack[filename].php %}
+{% set drupal = stack[filename].drupal %}
+{% set pgsql = stack[filename].pgsql %}
+
 jobs:
   {{ test }}:
     name: 'PHP {{ php }} - Drupal {{ drupal }} - PostgreSQL {{ pgsql }}'

--- a/templates/generator/tripal_admin/readme-grid-workflow.twig
+++ b/templates/generator/tripal_admin/readme-grid-workflow.twig
@@ -6,15 +6,16 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - '{{ branch }}'
-      - '{{ branches }}'
+    {% for branch in branches %}
+      - {{ branch }}
+    {% endfor %}
   schedule:
     - cron: '{{ cron }}'
 
 permissions: read-all
 
 jobs:
-  running-tests:
+  {{ test }}:
     name: 'PHP {{ php }} - Drupal {{ drupal }} - PostgreSQL {{ pgsql }}'
     runs-on: 'ubuntu-latest'
     steps:

--- a/templates/generator/tripal_admin/readme-grid-workflow.twig
+++ b/templates/generator/tripal_admin/readme-grid-workflow.twig
@@ -1,0 +1,29 @@
+name: 'PHPUnit'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - '4.x'
+      - '{{ branches }}'
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions: read-all
+
+jobs:
+  running-tests:
+    name: 'PHP {{ php }} : Drupal {{ drupal }}'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout Repository'
+        uses: 'actions/checkout@v4'
+      - name: 'Run Automated testing'
+        uses: '{{ test_actions }}'
+        with:
+          directory-name: {{ module_directory_name }}
+          modules: {{ apply_module }}
+          php-version: {{ php }}
+          drupal-version: {{ drupal }}
+          pgsql-version: {{ pgsql }}
+          build-image: true


### PR DESCRIPTION
Issue #5 

Create a command to generate the testing grid and associated workflow files.

Manual Testing
1. Clone and launch Docker image/container for this module.
2. Switch to branch readmeGridGenerators
3. Enable `drush en tripal_devtools`
4. Copy and paste the require ALL-PHPUnit.yml file into tripal_devtools/.github/workflows

[ALL-PHPUnit.yml.zip](https://github.com/user-attachments/files/23664040/ALL-PHPUnit.yml.zip)

5. Execute the command in the Terminal pane of VSCode IDE:

```
drush generate tripal-admin:readme-grid

```

6. Press Enter key [Yes] to all the prompts.
7. Verify the grid and the grid files generated.

File setup:
PHP: 1, 2, 3
DRUPAL, 1, 2, 3
PGSQL: 1, 2

Exclusions: 
- PHP 2 Drupal 3
- PHP 3 Drupal 1

Expected grid:

p/d 1 2 3
1 ✔️  ✔️  ✔️ 
2 ✔️  ✔️  -
3 -   ✔️  ✔️ 

Repeat and add shorthand exclusion format:

```
     exclude:
          - php-version: "2"
            drupal-version: "3"
          - php-version: "3"
            drupal-version: "1"
          - pgsql-version: "2" ◀️ ◀️ ◀️ ◀️ ◀️ ◀️ 
            drupal-version: "3"
```

Expected grid:

p/d 1 2 3
1 ✔️  ✔️  - 
2 ✔️  ✔️  -
3 -   ✔️   - 

Plus exclusion note:
- PHP 1 - Drupal 3
-  PHP 2 - Drupal 3
-  PHP 3 - Drupal 3

**Running command in package module.**

The command will attempt to determine if the module name is a package module - that is, it has sub-modules contained.  Once determined, it will confirm this setup to the user. If the user chooses to proceed (responding Yes), a prompt will appear asking whether the workflow should apply to all sub-modules. Alternatively, the user can review the list and select only the desired sub-modules (see example prompts below).

In technical terms, this list of modules will become the value in the configuration yml - **modules** (see below).

```

jobs:
  running-tests:
    name: 'PHP 3 - Drupal 3 - PostgreSQL 2'
    runs-on: 'ubuntu-latest'
    steps:
      - name: 'Checkout Repository'
        uses: 'actions/checkout@v4'
      - name: 'Run Automated testing'
        uses: 'tripal/test-tripal-action@v1.7'
        with:
          directory-name: 'tripal_devtools'
          modules: 'LIST OF MODULES' ◀️ ◀️ ◀️ ◀️ ◀️ ◀️ 
          php-version: '3'
          drupal-version: '3'
          pgsql-version: '2'
          build-image: TRUE
          dockerfile: 'Dockerfile'

```

<img width="784" height="355" alt="Screenshot 2025-11-20 at 3 56 09 PM" src="https://github.com/user-attachments/assets/8d3f6eab-2da7-42db-ac4b-d5726b3890db" />


A prompt before the grid output will allow for omission of specific column in the grid while still generating relevant workflow file.

