### PR TITLE
Single quote the string values in info.yml

### DIFF
--- a/templates/generator/tripal_extension_module/module.info.yml.twig
+++ b/templates/generator/tripal_extension_module/module.info.yml.twig
@@ -1,14 +1,14 @@
-name: {{ name }}
-type: module
-description: {{ description }}
-package: {{ package }}
-core_version_requirement: ^10.4 | ^11.1
+name: '{{ name }}'
+type: 'module'
+description: '{{ description }}'
+package: '{{ package }}'
+core_version_requirement: '^10.4 | ^11.1'
 {% if dependencies %}
 dependencies:
   {% for dependency in dependencies %}
-  - {{ dependency }}
+  - '{{ dependency }}'
   {% endfor %}
 {% endif %}
 {% if form %}
-configure: {{ machine_name }}.settings_form
+configure: '{{ machine_name }}.settings_form'
 {% endif %}


### PR DESCRIPTION
Adds single quotes for the info.yml file template. The other templates already seem to satisfy the syntax requirement.

As noted in the issue, I'm unsure if we should quote the "type" line. It doesn't seem to be the standard among other modules but yamlint complains. Alternatively, we modify the linter's behavior to _not_ trigger on instances where it isn't necessary but still trigger on other strings.

## Testing?
On this branch, use the `drush generate tripal:extension-module` command to generate an extension module. In the newly created extension's <module_name>.info.yml file, all of the strings should have single quotes as required by yaml syntax. Drupal should let it be installed without issue.